### PR TITLE
Restructure simulation response: nested metadata + age-group summary + quantile stats

### DIFF
--- a/app/api/v1/endpoints/simulations.py
+++ b/app/api/v1/endpoints/simulations.py
@@ -3,12 +3,32 @@
 This module provides the endpoint for running epidemic simulations.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Body, HTTPException
+from fastapi.openapi.models import Example
 
 from ....services.simulation_service import run_simulation
 from ..schemas.simulation import SimulationRequest, SimulationResponse
 
 router = APIRouter()
+
+SIMULATION_REQUEST_EXAMPLES: dict[str, Example] = {
+    "SIR": Example(
+        summary="Basic SIR simulation",
+        description="Run a Susceptible-Infected-Recovered model on the US population over two months.",
+        value={
+            "model": {
+                "preset": "SIR",
+                "parameters": {"transmission_rate": 0.3, "recovery_rate": 0.1},
+            },
+            "population": {"name": "United_States"},
+            "simulation": {
+                "start_date": "2024-01-01",
+                "end_date": "2024-03-01",
+                "Nsim": 10,
+            },
+        },
+    ),
+}
 
 
 @router.post(
@@ -17,7 +37,9 @@ router = APIRouter()
     summary="Run epidemic simulation",
     description="Execute an epidemic simulation with the specified configuration.",
 )
-async def create_simulation(request: SimulationRequest) -> SimulationResponse:
+async def create_simulation(
+    request: SimulationRequest = Body(..., openapi_examples=SIMULATION_REQUEST_EXAMPLES),
+) -> SimulationResponse:
     """Run an epidemic simulation.
 
     Accepts a simulation configuration and returns results including

--- a/app/api/v1/schemas/simulation.py
+++ b/app/api/v1/schemas/simulation.py
@@ -263,31 +263,38 @@ class TransitionResults(BaseModel):
     )
 
 
-class SummaryStatistic(BaseModel):
-    """A summary statistic with median and confidence interval."""
+class StatisticQuantiles(BaseModel):
+    """Quantile values for a summary statistic, keyed by quantile string (e.g. `0.5`)."""
 
-    median: float = Field(..., description="Median value across simulation runs.")
-    ci_95: list[float] = Field(..., min_length=2, max_length=2, description="95% confidence interval [lower, upper].")
+    quantiles: dict[str, float] = Field(
+        ...,
+        description="Quantile to value mapping, e.g. `{\"0.025\": ..., \"0.5\": ..., \"0.975\": ...}`.",
+    )
 
 
 class PeakStatistic(BaseModel):
-    """Peak statistic with date."""
+    """Peak statistic for a compartment in one age group."""
 
-    median: float = Field(..., description="Median peak value across simulation runs.")
-    ci_95: list[float] = Field(..., min_length=2, max_length=2, description="95% confidence interval [lower, upper].")
-    peak_date: str | None = Field(default=None, description="Date of the median peak.")
+    quantiles: dict[str, float] = Field(
+        ...,
+        description="Peak value per quantile, e.g. `{\"0.025\": ..., \"0.5\": ..., \"0.975\": ...}`.",
+    )
+    peak_date: str | None = Field(
+        default=None,
+        description="Date of the peak from the median trajectory.",
+    )
 
 
 class SummaryResults(BaseModel):
     """Summary statistics of the simulation."""
 
-    peaks: dict[str, PeakStatistic] | None = Field(
+    peaks: dict[str, dict[str, PeakStatistic]] | None = Field(
         default=None,
-        description="Peak statistics per compartment.",
+        description="Peak statistics: `compartment -> age_group -> {quantiles, peak_date}`.",
     )
-    totals: dict[str, SummaryStatistic] | None = Field(
+    totals: dict[str, dict[str, StatisticQuantiles]] | None = Field(
         default=None,
-        description="Total transition counts.",
+        description="Cumulative transition totals: `transition -> age_group -> {quantiles}`.",
     )
 
 

--- a/app/api/v1/schemas/simulation.py
+++ b/app/api/v1/schemas/simulation.py
@@ -8,6 +8,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, BeforeValidator, Field, model_validator
 
+from .population import AgeGroupInfo
+
 
 def _ensure_list(v: str | list[str]) -> list[str]:
     """Accept a single string or a list of strings, always return a list."""
@@ -339,19 +341,53 @@ class SimulationResultsData(BaseModel):
     )
 
 
-class SimulationMetadata(BaseModel):
-    """Metadata about the simulation run."""
+class ModelMetadata(BaseModel):
+    """Model section of simulation metadata. Mirrors the `model` section of the request."""
 
-    model_preset: str | None = Field(default=None, description="Preset name if a preset was used.")
+    preset: str | None = Field(default=None, description="Preset name if a preset was used.")
     compartments: list[str] = Field(..., description="Compartment names in the model.")
-    population_name: str = Field(..., description="Population identifier.")
-    population_size: int = Field(..., description="Total population size.")
-    n_age_groups: int = Field(..., description="Number of age groups.")
+
+
+class PopulationMetadata(BaseModel):
+    """Population section of simulation metadata. Mirrors the `population` section of the request and adds resolved/derived values."""
+
+    name: str = Field(..., description="Population identifier.")
+    contacts_source: str | None = Field(
+        default=None,
+        description="Resolved contact matrix source actually used.",
+    )
+    layers: list[str] | None = Field(
+        default=None,
+        description="Resolved contact layers actually used.",
+    )
+    age_group_mapping: dict[str, list[str]] | None = Field(
+        default=None,
+        description="Custom age group aggregation, echoed back if the request supplied one.",
+    )
+    total: int = Field(..., description="Total population size.")
+    age_groups: list[AgeGroupInfo] = Field(
+        ...,
+        description="Population count per age group, in model order.",
+    )
+
+
+class SimulationRunMetadata(BaseModel):
+    """Simulation section of metadata. Mirrors the `simulation` section of the request."""
+
     start_date: str = Field(..., description="Simulation start date.")
     end_date: str = Field(..., description="Simulation end date.")
-    n_simulations: int = Field(..., description="Number of simulation runs.")
+    Nsim: int = Field(..., description="Number of simulation runs.")
     dt: float = Field(..., description="Time step in days.")
     seed: int | None = Field(default=None, description="Random seed used.")
+    resample_frequency: str = Field(..., description="Resampling frequency.")
+
+
+class SimulationMetadata(BaseModel):
+    """Metadata about the simulation run, grouped to mirror the request shape."""
+
+    model: ModelMetadata = Field(..., description="Model configuration used for the run.")
+    population: PopulationMetadata = Field(..., description="Resolved population configuration and derived counts.")
+    simulation: SimulationRunMetadata = Field(..., description="Simulation execution parameters used for the run.")
 
 
 class SimulationResponse(BaseModel):

--- a/app/api/v1/schemas/simulation.py
+++ b/app/api/v1/schemas/simulation.py
@@ -192,16 +192,16 @@ class SummaryConfig(BaseModel):
     peak_compartments: list[str] | None = Field(
         default=None,
         description=(
-            "Base compartment names to compute peak statistics for. "
-            "Omit to include every compartment; pass `[]` to explicitly skip peak stats. "
+            "Compartment names to compute peak statistics for, e.g. `[\"Infected\"]`. "
+            "Omit to include every compartment; pass `[]` to explicitly skip returning this summary. "
             "Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
         ),
     )
     total_transitions: list[str] | None = Field(
         default=None,
         description=(
-            "Base transition names (e.g. `Susceptible_to_Infected`) to compute cumulative totals for. "
-            "Omit to include every transition; pass `[]` to explicitly skip totals. "
+            "Transition names to compute cumulative totals for, e.g. `[\"Susceptible_to_Infected\"]`. "
+            "Omit to include every transition; pass `[]` to explicitly skip returning this summary. "
             "Per-quantile total event counts are returned for each included age group."
         ),
     )

--- a/app/api/v1/schemas/simulation.py
+++ b/app/api/v1/schemas/simulation.py
@@ -226,25 +226,6 @@ class OutputConfig(BaseModel):
 class SimulationRequest(BaseModel):
     """Complete simulation request."""
 
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {
-                    "model": {
-                        "preset": "SIR",
-                        "parameters": {"transmission_rate": 0.3, "recovery_rate": 0.1},
-                    },
-                    "population": {"name": "United_States"},
-                    "simulation": {
-                        "start_date": "2024-01-01",
-                        "end_date": "2024-03-01",
-                        "Nsim": 10,
-                    },
-                }
-            ]
-        }
-    }
-
     model: ModelConfig = Field(..., description="Epidemic model configuration.")
     population: PopulationConfig = Field(..., description="Population configuration.")
     simulation: SimulationConfig = Field(..., description="Simulation execution parameters.")

--- a/app/api/v1/schemas/simulation.py
+++ b/app/api/v1/schemas/simulation.py
@@ -183,43 +183,61 @@ class ParameterOverrideConfig(BaseModel):
 
 
 class SummaryConfig(BaseModel):
-    """Configuration for summary statistics."""
+    """Configuration for summary statistics.
+
+    Summary is returned by default for every compartment and transition, broken
+    down by age group and by the quantiles requested in `output.quantiles`.
+    Use the fields below to narrow that down."""
 
     peak_compartments: list[str] | None = Field(
         default=None,
-        description="Compartments to compute peak statistics for. Returns peak value, CI, and peak date.",
+        description=(
+            "Base compartment names to compute peak statistics for. "
+            "Omit to include every compartment; pass `[]` to explicitly skip peak stats. "
+            "Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
+        ),
     )
     total_transitions: list[str] | None = Field(
         default=None,
-        description="Transitions to compute cumulative totals for. Returns median and CI.",
+        description=(
+            "Base transition names (e.g. `Susceptible_to_Infected`) to compute cumulative totals for. "
+            "Omit to include every transition; pass `[]` to explicitly skip totals. "
+            "Per-quantile total event counts are returned for each included age group."
+        ),
     )
 
 
 class OutputConfig(BaseModel):
-    """Output configuration."""
+    """Output configuration. Everything is optional; defaults return all compartments, all transitions, all age groups (including `total`), all standard quantiles, and a populated `summary`."""
 
     quantiles: list[float] | None = Field(
         default=None,
-        description="Quantiles to compute. Default: `[0.025, 0.05, 0.25, 0.5, 0.75, 0.95, 0.975]`.",
+        description=(
+            "Quantiles to compute for trajectories and summary. "
+            "Default: `[0.025, 0.05, 0.25, 0.5, 0.75, 0.95, 0.975]`."
+        ),
     )
     include_trajectories: bool = Field(
-        default=False, description="Include raw trajectory data (can be large)."
+        default=False, description="Include raw per-run trajectory data in the response. Can be large."
     )
     compartments: list[str] | None = Field(
         default=None,
-        description="Compartments to include in output. Default: all.",
+        description="Compartments to include in the trajectory section. Default: all. Does not affect `summary`.",
     )
     transitions: list[str] | None = Field(
         default=None,
-        description="Transitions to include in output. Default: all.",
+        description="Transitions to include in the trajectory section. Default: all. Does not affect `summary`.",
     )
     age_groups: list[str] | None = Field(
         default=None,
-        description="Age groups to include, e.g. `[\"0-4\", \"5-19\", \"total\"]`. Default: all.",
+        description=(
+            "Age groups to include in both trajectories and summary, "
+            "e.g. `[\"0-4\", \"5-19\", \"total\"]`. Default: all age groups plus `total`."
+        ),
     )
     summary: SummaryConfig | None = Field(
         default=None,
-        description="Summary statistics configuration.",
+        description="Summary statistics configuration. Omit to return the default summary.",
     )
 
 

--- a/app/api/v1/schemas/simulation.py
+++ b/app/api/v1/schemas/simulation.py
@@ -192,16 +192,18 @@ class SummaryConfig(BaseModel):
     peak_compartments: list[str] | None = Field(
         default=None,
         description=(
-            "Compartment names to compute peak statistics for, e.g. `[\"Infected\"]`. "
-            "Omit to include every compartment; pass `[]` to explicitly skip returning this summary. "
+            "By default, peak statistics are returned for every compartment. "
+            "Pass a list to narrow the response, e.g. `[\"Infected\"]`, "
+            "or pass `[]` to explicitly skip returning this summary. "
             "Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
         ),
     )
     total_transitions: list[str] | None = Field(
         default=None,
         description=(
-            "Transition names to compute cumulative totals for, e.g. `[\"Susceptible_to_Infected\"]`. "
-            "Omit to include every transition; pass `[]` to explicitly skip returning this summary. "
+            "By default, cumulative totals are returned for every transition. "
+            "Pass a list to narrow the response, e.g. `[\"Susceptible_to_Infected\"]`, "
+            "or pass `[]` to explicitly skip returning this summary. "
             "Per-quantile total event counts are returned for each included age group."
         ),
     )

--- a/app/config.py
+++ b/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="EPYDEMIX_")
 
     app_name: str = "epydemix WebAPI"
-    app_version: str = "0.1.1"
+    app_version: str = "0.2.0"
     debug: bool = False
 
     # API settings

--- a/app/config.py
+++ b/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="EPYDEMIX_")
 
     app_name: str = "epydemix WebAPI"
-    app_version: str = "0.2.0"
+    app_version: str = "0.2.1"
     debug: bool = False
 
     # API settings

--- a/app/services/results_processing.py
+++ b/app/services/results_processing.py
@@ -14,13 +14,14 @@ from ..api.v1.schemas.simulation import (
     CompartmentResults,
     OutputConfig,
     PeakStatistic,
-    SummaryConfig,
+    StatisticQuantiles,
     SummaryResults,
-    SummaryStatistic,
     TrajectoriesResults,
     TrajectoryData,
     TransitionResults,
 )
+
+DEFAULT_QUANTILES: list[float] = [0.025, 0.05, 0.25, 0.5, 0.75, 0.95, 0.975]
 from ..utils.column_utils import parse_column_name
 
 
@@ -138,87 +139,126 @@ def extract_trajectories(
     return TrajectoriesResults(dates=dates, runs=runs)
 
 
+def _format_date(date_val) -> str | None:
+    """Format a date value as YYYY-MM-DD, returning None for NaT."""
+    ts = pd.Timestamp(date_val)
+    if pd.isna(ts):
+        return None
+    return ts.strftime("%Y-%m-%d")
+
+
+def _resolve_age_groups(
+    requested: list[str] | None,
+    stacked: dict,
+    bases: list[str],
+) -> list[str]:
+    """Resolve the age groups to compute summary stats for.
+
+    If the caller did not specify a filter, returns every age group that
+    appears in the stacked data for the given bases, in a stable order
+    (insertion order of the stacked dict) with `total` last if present.
+    """
+    seen: dict[str, None] = {}
+    for key in stacked:
+        for base in bases:
+            if key == f"{base}_total":
+                seen.setdefault("total", None)
+                break
+            if key.startswith(base + "_"):
+                seen.setdefault(key[len(base) + 1 :], None)
+                break
+    available = list(seen.keys())
+    # Move "total" to the end for a more natural order.
+    if "total" in available:
+        available = [g for g in available if g != "total"] + ["total"]
+
+    if requested is None:
+        return available
+    return [g for g in requested if g in available]
+
+
 def compute_summary(
     results: SimulationResults,
-    summary_config: SummaryConfig | None,
+    peak_compartments: list[str],
+    total_transitions: list[str],
+    age_groups: list[str] | None,
+    quantiles: list[float],
 ) -> SummaryResults | None:
     """Compute summary statistics from simulation results.
 
-    Calculates peak statistics for specified compartments and total counts
-    for specified transitions across all simulation runs.
+    For each requested compartment or transition, emits per-quantile peak or
+    cumulative-total statistics per age group. Peaks additionally include a
+    `peak_date` from the median trajectory of that age group.
 
     Parameters
     ----------
     results : SimulationResults
         Simulation results from epydemix.
-    summary_config : SummaryConfig or None
-        Configuration specifying which compartments and transitions to
-        compute statistics for. If None, returns None.
+    peak_compartments : list of str
+        Base compartment names to compute peak statistics for. Empty list
+        disables peak computation.
+    total_transitions : list of str
+        Base transition names (e.g. `S_to_I`) to compute cumulative totals
+        for. Empty list disables total computation.
+    age_groups : list of str or None
+        Age groups to include. `None` means every age group that has data
+        (ordered as they appear in the simulation, with `total` last).
+    quantiles : list of float
+        Quantiles to compute for each statistic (e.g. `[0.025, 0.5, 0.975]`).
 
     Returns
     -------
     SummaryResults or None
-        Summary statistics with peaks and totals, or None if no config
-        provided or no statistics could be computed.
+        Summary statistics, or None if neither peaks nor totals were
+        computed (for example, both input lists were empty).
     """
-    if summary_config is None:
-        return None
+    peaks: dict[str, dict[str, PeakStatistic]] = {}
+    totals: dict[str, dict[str, StatisticQuantiles]] = {}
 
-    peaks: dict[str, PeakStatistic] = {}
-    totals: dict[str, SummaryStatistic] = {}
-
-    # Compute peak statistics for requested compartments
-    if summary_config.peak_compartments:
+    if peak_compartments:
         stacked = results.get_stacked_compartments()
-        for comp_name in summary_config.peak_compartments:
-            # Try with _total suffix first, then without
-            comp_key = f"{comp_name}_total"
-            if comp_key not in stacked:
-                comp_key = comp_name
-                if comp_key not in stacked:
+        resolved_groups = _resolve_age_groups(age_groups, stacked, peak_compartments)
+        for comp_name in peak_compartments:
+            peak_by_group: dict[str, PeakStatistic] = {}
+            for age_group in resolved_groups:
+                key = f"{comp_name}_{age_group}"
+                if key not in stacked:
                     continue
+                comp_data = stacked[key]  # shape: (Nsim, timesteps)
+                peak_per_sim = np.max(comp_data, axis=1)
+                quantile_values = {
+                    str(q): float(np.quantile(peak_per_sim, q)) for q in quantiles
+                }
 
-            comp_data = stacked[comp_key]  # Shape: (Nsim, timesteps)
+                median_traj = np.median(comp_data, axis=0)
+                peak_idx = int(np.argmax(median_traj))
+                peak_date = None
+                if len(results.dates) > peak_idx:
+                    peak_date = _format_date(results.dates[peak_idx])
 
-            peak_per_sim = np.max(comp_data, axis=1)
-            peak_median = float(np.median(peak_per_sim))
-            peak_ci = [
-                float(np.percentile(peak_per_sim, 2.5)),
-                float(np.percentile(peak_per_sim, 97.5)),
-            ]
+                peak_by_group[age_group] = PeakStatistic(
+                    quantiles=quantile_values, peak_date=peak_date
+                )
+            if peak_by_group:
+                peaks[comp_name] = peak_by_group
 
-            # Find peak date (use median trajectory)
-            median_traj = np.median(comp_data, axis=0)
-            peak_idx = int(np.argmax(median_traj))
-            peak_date = None
-            if len(results.dates) > 0:
-                date_val = results.dates[peak_idx]
-                peak_date = pd.Timestamp(date_val).strftime("%Y-%m-%d")
-
-            peaks[comp_name] = PeakStatistic(
-                median=peak_median, ci_95=peak_ci, peak_date=peak_date
-            )
-
-    # Compute total counts for requested transitions
-    if summary_config.total_transitions:
+    if total_transitions:
         trans_stacked = results.get_stacked_transitions()
-        for trans_name in summary_config.total_transitions:
-            # Try with _total suffix first, then without
-            trans_key = f"{trans_name}_total"
-            if trans_key not in trans_stacked:
-                trans_key = trans_name
-                if trans_key not in trans_stacked:
+        resolved_groups = _resolve_age_groups(age_groups, trans_stacked, total_transitions)
+        for trans_name in total_transitions:
+            total_by_group: dict[str, StatisticQuantiles] = {}
+            for age_group in resolved_groups:
+                key = f"{trans_name}_{age_group}"
+                if key not in trans_stacked:
                     continue
-
-            trans_data = trans_stacked[trans_key]
-            total_per_sim = np.sum(trans_data, axis=1)
-            totals[trans_name] = SummaryStatistic(
-                median=float(np.median(total_per_sim)),
-                ci_95=[
-                    float(np.percentile(total_per_sim, 2.5)),
-                    float(np.percentile(total_per_sim, 97.5)),
-                ],
-            )
+                trans_data = trans_stacked[key]
+                total_per_sim = np.sum(trans_data, axis=1)
+                quantile_values = {
+                    str(q): float(np.quantile(total_per_sim, q)) for q in quantiles
+                }
+                total_by_group[age_group] = StatisticQuantiles(quantiles=quantile_values)
+            if total_by_group:
+                totals[trans_name] = total_by_group
 
     if not peaks and not totals:
         return None
@@ -299,8 +339,26 @@ def process_results(
     )
     transition_results = TransitionResults(dates=dates, data=trans_data)
 
-    # Compute summary statistics
-    summary = compute_summary(results, output_config.summary)
+    # Compute summary statistics. Default to all compartments/transitions when
+    # the user did not specify a field; an empty list is an explicit opt-out.
+    user_summary = output_config.summary
+    resolved_peaks = (
+        user_summary.peak_compartments
+        if user_summary is not None and user_summary.peak_compartments is not None
+        else compartment_names
+    )
+    resolved_totals = (
+        user_summary.total_transitions
+        if user_summary is not None and user_summary.total_transitions is not None
+        else transition_names
+    )
+    summary = compute_summary(
+        results,
+        peak_compartments=resolved_peaks,
+        total_transitions=resolved_totals,
+        age_groups=output_config.age_groups,
+        quantiles=output_config.quantiles or DEFAULT_QUANTILES,
+    )
 
     # Include raw trajectories if requested
     trajectories = None

--- a/app/services/simulation_service.py
+++ b/app/services/simulation_service.py
@@ -11,17 +11,57 @@ from epydemix.model.epimodel import EpiModel
 from epydemix.model.predefined_models import load_predefined_model
 from epydemix.population.population import load_epydemix_population
 
+from ..api.v1.schemas.population import AgeGroupInfo
 from ..api.v1.schemas.simulation import (
     InitialConditionsConfig,
     InterventionConfig,
     ModelConfig,
+    ModelMetadata,
     ParameterOverrideConfig,
     PopulationConfig,
+    PopulationMetadata,
     SimulationMetadata,
     SimulationRequest,
     SimulationResponse,
+    SimulationRunMetadata,
 )
+from .population_service import _resolve_contacts_source
 from .results_processing import process_results
+
+DEFAULT_LAYERS = ["home", "work", "school", "community"]
+
+
+def _build_population_metadata(
+    request_population: PopulationConfig,
+    model_population,
+) -> PopulationMetadata:
+    """Build PopulationMetadata from the request and the loaded model population."""
+    age_groups = [
+        AgeGroupInfo(name=str(name), population=int(count))
+        for name, count in zip(model_population.Nk_names, model_population.Nk)
+    ]
+    return PopulationMetadata(
+        name=request_population.name,
+        contacts_source=_resolve_contacts_source(
+            request_population.name, request_population.contacts_source
+        ),
+        layers=request_population.layers or DEFAULT_LAYERS,
+        age_group_mapping=request_population.age_group_mapping,
+        total=int(model_population.total_population),
+        age_groups=age_groups,
+    )
+
+
+def _build_run_metadata(request: SimulationRequest) -> SimulationRunMetadata:
+    """Build SimulationRunMetadata from the request."""
+    return SimulationRunMetadata(
+        start_date=request.simulation.start_date,
+        end_date=request.simulation.end_date,
+        Nsim=request.simulation.Nsim,
+        dt=request.simulation.dt,
+        seed=request.simulation.seed,
+        resample_frequency=request.simulation.resample_frequency,
+    )
 
 
 def create_model(config: ModelConfig) -> EpiModel:
@@ -96,7 +136,7 @@ def setup_population(model: EpiModel, config: PopulationConfig) -> None:
     population = load_epydemix_population(
         population_name=config.name,
         contacts_source=config.contacts_source,
-        layers=config.layers or ["home", "work", "school", "community"],
+        layers=config.layers or DEFAULT_LAYERS,
         age_group_mapping=config.age_group_mapping,
     )
     model.set_population(population)
@@ -275,16 +315,12 @@ def run_simulation(request: SimulationRequest) -> SimulationResponse:
 
         # Build metadata
         metadata = SimulationMetadata(
-            model_preset=request.model.preset,
-            compartments=model.compartments,
-            population_name=request.population.name,
-            population_size=int(model.population.total_population),
-            n_age_groups=model.population.num_groups,
-            start_date=request.simulation.start_date,
-            end_date=request.simulation.end_date,
-            n_simulations=request.simulation.Nsim,
-            dt=request.simulation.dt,
-            seed=request.simulation.seed,
+            model=ModelMetadata(
+                preset=request.model.preset,
+                compartments=model.compartments,
+            ),
+            population=_build_population_metadata(request.population, model.population),
+            simulation=_build_run_metadata(request),
         )
 
         return SimulationResponse(
@@ -299,15 +335,19 @@ def run_simulation(request: SimulationRequest) -> SimulationResponse:
             simulation_id=simulation_id,
             status="failed",
             metadata=SimulationMetadata(
-                compartments=[],
-                population_name=request.population.name,
-                population_size=0,
-                n_age_groups=0,
-                start_date=request.simulation.start_date,
-                end_date=request.simulation.end_date,
-                n_simulations=request.simulation.Nsim,
-                dt=request.simulation.dt,
-                seed=request.simulation.seed,
+                model=ModelMetadata(
+                    preset=request.model.preset,
+                    compartments=[],
+                ),
+                population=PopulationMetadata(
+                    name=request.population.name,
+                    contacts_source=request.population.contacts_source,
+                    layers=request.population.layers,
+                    age_group_mapping=request.population.age_group_mapping,
+                    total=0,
+                    age_groups=[],
+                ),
+                simulation=_build_run_metadata(request),
             ),
             error=str(e),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epydemix-webapi"
-version = "0.1.1"
+version = "0.2.0"
 description = "REST API for running epidemic simulations on epydemix"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epydemix-webapi"
-version = "0.2.0"
+version = "0.2.1"
 description = "REST API for running epidemic simulations on epydemix"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -349,3 +349,136 @@ def test_simulation_population_metadata(client):
         assert "name" in entry
         assert isinstance(entry["population"], int)
     assert sum(entry["population"] for entry in age_groups) == population["total"]
+
+
+def test_simulation_summary_default_populated(client):
+    """Summary should be populated by default: all compartments and transitions, all age groups."""
+    request = {
+        "model": {"preset": "SIR"},
+        "population": {"name": "United_States"},
+        "simulation": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-15",
+            "Nsim": 3,
+        },
+    }
+
+    response = client.post("/api/v1/simulations", json=request)
+    assert response.status_code == 200
+
+    summary = response.json()["results"]["summary"]
+    assert summary is not None
+
+    assert set(summary["peaks"].keys()) == {"Susceptible", "Infected", "Recovered"}
+    for by_age in summary["peaks"].values():
+        assert "total" in by_age
+        # Any per-age-group entry (including total) has quantiles + peak_date.
+        for stat in by_age.values():
+            assert "quantiles" in stat
+            assert "0.5" in stat["quantiles"]
+            assert "peak_date" in stat
+
+    assert set(summary["totals"].keys()) == {"Susceptible_to_Infected", "Infected_to_Recovered"}
+    for by_age in summary["totals"].values():
+        assert "total" in by_age
+        for stat in by_age.values():
+            assert "quantiles" in stat
+            assert "0.5" in stat["quantiles"]
+
+
+def test_simulation_summary_user_override(client):
+    """User-supplied summary fields override the per-field default, other fields keep defaulting."""
+    request = {
+        "model": {"preset": "SIR"},
+        "population": {"name": "United_States"},
+        "simulation": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-15",
+            "Nsim": 3,
+        },
+        "output": {
+            "summary": {
+                "peak_compartments": ["Infected"],
+            },
+        },
+    }
+
+    response = client.post("/api/v1/simulations", json=request)
+    assert response.status_code == 200
+
+    summary = response.json()["results"]["summary"]
+    assert set(summary["peaks"].keys()) == {"Infected"}
+    # total_transitions was not specified -> defaults to all
+    assert set(summary["totals"].keys()) == {"Susceptible_to_Infected", "Infected_to_Recovered"}
+
+
+def test_simulation_summary_explicit_opt_out(client):
+    """An explicit empty list opts out of that part of the summary; both -> summary is null."""
+    request = {
+        "model": {"preset": "SIR"},
+        "population": {"name": "United_States"},
+        "simulation": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-15",
+            "Nsim": 3,
+        },
+        "output": {
+            "summary": {
+                "peak_compartments": [],
+                "total_transitions": [],
+            },
+        },
+    }
+
+    response = client.post("/api/v1/simulations", json=request)
+    assert response.status_code == 200
+
+    assert response.json()["results"]["summary"] is None
+
+
+def test_simulation_summary_honors_quantiles(client):
+    """output.quantiles should drive which quantiles appear in the summary."""
+    request = {
+        "model": {"preset": "SIR"},
+        "population": {"name": "United_States"},
+        "simulation": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-15",
+            "Nsim": 3,
+        },
+        "output": {
+            "quantiles": [0.1, 0.5, 0.9],
+        },
+    }
+
+    response = client.post("/api/v1/simulations", json=request)
+    assert response.status_code == 200
+
+    peaks = response.json()["results"]["summary"]["peaks"]
+    quantiles = peaks["Infected"]["total"]["quantiles"]
+    assert set(quantiles.keys()) == {"0.1", "0.5", "0.9"}
+
+
+def test_simulation_summary_honors_age_groups(client):
+    """output.age_groups should filter which age groups appear in the summary."""
+    request = {
+        "model": {"preset": "SIR"},
+        "population": {"name": "United_States"},
+        "simulation": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-15",
+            "Nsim": 3,
+        },
+        "output": {
+            "age_groups": ["total"],
+        },
+    }
+
+    response = client.post("/api/v1/simulations", json=request)
+    assert response.status_code == 200
+
+    summary = response.json()["results"]["summary"]
+    for by_age in summary["peaks"].values():
+        assert set(by_age.keys()) == {"total"}
+    for by_age in summary["totals"].values():
+        assert set(by_age.keys()) == {"total"}

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -25,9 +25,9 @@ def test_run_sir_simulation_with_preset(client):
     data = response.json()
     assert data["status"] == "completed"
     assert "simulation_id" in data
-    assert data["metadata"]["model_preset"] == "SIR"
-    assert data["metadata"]["population_name"] == "United_States"
-    assert data["metadata"]["n_simulations"] == 10
+    assert data["metadata"]["model"]["preset"] == "SIR"
+    assert data["metadata"]["population"]["name"] == "United_States"
+    assert data["metadata"]["simulation"]["Nsim"] == 10
 
     # Check results structure
     assert "results" in data
@@ -58,7 +58,7 @@ def test_run_seir_simulation(client):
 
     data = response.json()
     assert data["status"] == "completed"
-    assert "Exposed" in data["metadata"]["compartments"]
+    assert "Exposed" in data["metadata"]["model"]["compartments"]
 
 
 def test_simulation_with_intervention(client):
@@ -177,7 +177,7 @@ def test_custom_model_simulation(client):
 
     data = response.json()
     assert data["status"] == "completed"
-    assert data["metadata"]["compartments"] == ["S", "I", "R"]
+    assert data["metadata"]["model"]["compartments"] == ["S", "I", "R"]
 
 
 def test_simulation_with_custom_age_groups(client):
@@ -213,7 +213,8 @@ def test_simulation_with_custom_age_groups(client):
     data = response.json()
     assert data["status"] == "completed"
     # Custom age groups should result in 4 age groups
-    assert data["metadata"]["n_age_groups"] == 4
+    assert len(data["metadata"]["population"]["age_groups"]) == 4
+    assert data["metadata"]["population"]["age_group_mapping"] == request["population"]["age_group_mapping"]
 
 
 def test_simulation_with_seed_reproducibility(client):
@@ -239,8 +240,8 @@ def test_simulation_with_seed_reproducibility(client):
     data1 = response1.json()
     data2 = response2.json()
 
-    assert data1["metadata"]["seed"] == 42
-    assert data2["metadata"]["seed"] == 42
+    assert data1["metadata"]["simulation"]["seed"] == 42
+    assert data2["metadata"]["simulation"]["seed"] == 42
 
     # Results should be identical with same seed
     assert data1["results"]["compartments"] == data2["results"]["compartments"]
@@ -271,8 +272,8 @@ def test_simulation_with_different_seeds(client):
     data1 = response1.json()
     data2 = response2.json()
 
-    assert data1["metadata"]["seed"] == 42
-    assert data2["metadata"]["seed"] == 123
+    assert data1["metadata"]["simulation"]["seed"] == 42
+    assert data2["metadata"]["simulation"]["seed"] == 123
 
     # Results should be different with different seeds
     assert data1["results"]["compartments"] != data2["results"]["compartments"]
@@ -317,3 +318,34 @@ def test_simulation_include_trajectories(client):
         for comp_name, age_groups in run["compartments"].items():
             assert "total" in age_groups
             assert len(age_groups) == 1  # Only "total" age group
+
+
+def test_simulation_population_metadata(client):
+    """Population metadata should include total, per-age-group counts, and resolved contacts config."""
+    request = {
+        "model": {"preset": "SIR"},
+        "population": {"name": "United_States"},
+        "simulation": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-10",
+            "Nsim": 3,
+        },
+    }
+
+    response = client.post("/api/v1/simulations", json=request)
+    assert response.status_code == 200
+
+    population = response.json()["metadata"]["population"]
+
+    assert population["name"] == "United_States"
+    assert population["total"] > 0
+    assert population["contacts_source"] is not None
+    assert population["layers"] == ["home", "work", "school", "community"]
+    assert population["age_group_mapping"] is None
+
+    age_groups = population["age_groups"]
+    assert len(age_groups) > 0
+    for entry in age_groups:
+        assert "name" in entry
+        assert isinstance(entry["population"], int)
+    assert sum(entry["population"] for entry in age_groups) == population["total"]

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "epydemix-webapi"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "epydemix" },

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "epydemix-webapi"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "epydemix" },

--- a/web/docs/guides/running-a-simulation.mdx
+++ b/web/docs/guides/running-a-simulation.mdx
@@ -56,16 +56,32 @@ The response contains `metadata`, `results`, and a `status` field.
   "simulation_id": "sim_c9617343b215",
   "status": "completed",
   "metadata": {
-    "model_preset": "SIR",
-    "compartments": ["Susceptible", "Infected", "Recovered"],
-    "population_name": "United_States",
-    "population_size": 338120586,
-    "n_age_groups": 5,
-    "start_date": "2024-01-01",
-    "end_date": "2024-06-01",
-    "n_simulations": 10,
-    "dt": 1.0,
-    "seed": null
+    "model": {
+      "preset": "SIR",
+      "compartments": ["Susceptible", "Infected", "Recovered"]
+    },
+    "population": {
+      "name": "United_States",
+      "contacts_source": "mistry_2021",
+      "layers": ["home", "work", "school", "community"],
+      "age_group_mapping": null,
+      "total": 338120586,
+      "age_groups": [
+        { "name": "0-4", "population": 18608139 },
+        { "name": "5-19", "population": 63540783 },
+        { "name": "20-49", "population": 132780169 },
+        { "name": "50-64", "population": 63172279 },
+        { "name": "65+", "population": 60019216 }
+      ]
+    },
+    "simulation": {
+      "start_date": "2024-01-01",
+      "end_date": "2024-06-01",
+      "Nsim": 10,
+      "dt": 1.0,
+      "seed": null,
+      "resample_frequency": "D"
+    }
   },
   "results": {
     "compartments": {

--- a/web/docs/guides/running-a-simulation.mdx
+++ b/web/docs/guides/running-a-simulation.mdx
@@ -49,7 +49,7 @@ We'll use the `SIR` preset.
 
 ## 4. Read the response
 
-The response contains `metadata`, `results`, and a `status` field.
+The response contains `metadata`, `results`, and a `status` field. By default the API returns everything: all compartments and transitions, all age groups (plus `total`), all seven standard quantiles, and a `summary` with peaks and cumulative totals per age group. You can narrow any of these via `output` (see [Customizing output](#5-customizing-output)).
 
 ```json
 {
@@ -107,6 +107,28 @@ The response contains `metadata`, `results`, and a `status` field.
           }
         }
       }
+    },
+    "summary": {
+      "peaks": {
+        "Infected": {
+          "total": {
+            "quantiles": {
+              "0.025": 121800000.0,
+              "0.5":   124500000.0,
+              "0.975": 127100000.0
+            },
+            "peak_date": "2024-02-14"
+          },
+          "0-4":  { "quantiles": { "0.5": 4120000.0, "...": 0 }, "peak_date": "2024-02-13" },
+          "65+":  { "quantiles": { "0.5": 16800000.0, "...": 0 }, "peak_date": "2024-02-16" }
+        }
+      },
+      "totals": {
+        "Susceptible_to_Infected": {
+          "total": { "quantiles": { "0.025": 213000000.0, "0.5": 215000000.0, "0.975": 217000000.0 } },
+          "0-4":   { "quantiles": { "0.5":  11800000.0, "...": 0 } }
+        }
+      }
     }
   }
 }
@@ -114,7 +136,33 @@ The response contains `metadata`, `results`, and a `status` field.
 
 Results are organized as quantiles (median, confidence intervals) across simulation runs. Both `compartments` and `transitions` follow the same nested structure: `name -> age_group -> quantile -> [values]`. The `total` age group is the sum across all age groups.
 
-## 5. Increase Nsim for production use
+`summary` mirrors that shape without the time dimension. `peaks` is `compartment -> age_group -> {quantiles, peak_date}` and carries the maximum value reached during the simulation window per quantile. `totals` is `transition -> age_group -> {quantiles}` and carries the cumulative number of transition events over the whole window.
+
+## 5. Customizing output
+
+Everything under `output` is optional; sensible defaults cover most cases. You can narrow the response with any combination of:
+
+```json
+{
+  "output": {
+    "quantiles": [0.1, 0.5, 0.9],
+    "age_groups": ["total"],
+    "compartments": ["Infected"],
+    "transitions": ["Susceptible_to_Infected"],
+    "summary": {
+      "peak_compartments": ["Infected"],
+      "total_transitions": []
+    }
+  }
+}
+```
+
+- `quantiles` drives both the trajectory quantiles and the `summary` quantiles.
+- `age_groups` filters both the trajectory age groups and the `summary` age groups. Use `["total"]` to skip the per-age breakdown entirely.
+- `compartments` / `transitions` filter the trajectory section only.
+- `summary.peak_compartments` / `summary.total_transitions`: omit to include every compartment / transition; pass `[]` to explicitly opt out of that half of the summary. An empty array for both leaves `summary: null`.
+
+## 6. Increase Nsim for production use
 
 Start with `Nsim: 10` while testing, then increase to 100 or more for reliable estimates.
 

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "epydemix WebAPI",
     "description": "REST API for running epidemic simulations with epydemix",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "servers": [
     {

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -1528,7 +1528,7 @@
               }
             ],
             "title": "Peak Compartments",
-            "description": "Base compartment names to compute peak statistics for. Omit to include every compartment; pass `[]` to explicitly skip peak stats. Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
+            "description": "Compartment names to compute peak statistics for, e.g. `[\"Infected\"]`. Omit to include every compartment; pass `[]` to explicitly skip returning this summary. Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
           },
           "total_transitions": {
             "anyOf": [
@@ -1543,7 +1543,7 @@
               }
             ],
             "title": "Total Transitions",
-            "description": "Base transition names (e.g. `Susceptible_to_Infected`) to compute cumulative totals for. Omit to include every transition; pass `[]` to explicitly skip totals. Per-quantile total event counts are returned for each included age group."
+            "description": "Transition names to compute cumulative totals for, e.g. `[\"Susceptible_to_Infected\"]`. Omit to include every transition; pass `[]` to explicitly skip returning this summary. Per-quantile total event counts are returned for each included age group."
           }
         },
         "type": "object",

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -727,12 +727,12 @@
               }
             ],
             "title": "Quantiles",
-            "description": "Quantiles to compute. Default: `[0.025, 0.05, 0.25, 0.5, 0.75, 0.95, 0.975]`."
+            "description": "Quantiles to compute for trajectories and summary. Default: `[0.025, 0.05, 0.25, 0.5, 0.75, 0.95, 0.975]`."
           },
           "include_trajectories": {
             "type": "boolean",
             "title": "Include Trajectories",
-            "description": "Include raw trajectory data (can be large).",
+            "description": "Include raw per-run trajectory data in the response. Can be large.",
             "default": false
           },
           "compartments": {
@@ -748,7 +748,7 @@
               }
             ],
             "title": "Compartments",
-            "description": "Compartments to include in output. Default: all."
+            "description": "Compartments to include in the trajectory section. Default: all. Does not affect `summary`."
           },
           "transitions": {
             "anyOf": [
@@ -763,7 +763,7 @@
               }
             ],
             "title": "Transitions",
-            "description": "Transitions to include in output. Default: all."
+            "description": "Transitions to include in the trajectory section. Default: all. Does not affect `summary`."
           },
           "age_groups": {
             "anyOf": [
@@ -778,7 +778,7 @@
               }
             ],
             "title": "Age Groups",
-            "description": "Age groups to include, e.g. `[\"0-4\", \"5-19\", \"total\"]`. Default: all."
+            "description": "Age groups to include in both trajectories and summary, e.g. `[\"0-4\", \"5-19\", \"total\"]`. Default: all age groups plus `total`."
           },
           "summary": {
             "anyOf": [
@@ -789,12 +789,12 @@
                 "type": "null"
               }
             ],
-            "description": "Summary statistics configuration."
+            "description": "Summary statistics configuration. Omit to return the default summary."
           }
         },
         "type": "object",
         "title": "OutputConfig",
-        "description": "Output configuration."
+        "description": "Output configuration. Everything is optional; defaults return all compartments, all transitions, all age groups (including `total`), all standard quantiles, and a populated `summary`."
       },
       "ParameterOverrideConfig": {
         "properties": {
@@ -1528,7 +1528,7 @@
               }
             ],
             "title": "Peak Compartments",
-            "description": "Compartments to compute peak statistics for. Returns peak value, CI, and peak date."
+            "description": "Base compartment names to compute peak statistics for. Omit to include every compartment; pass `[]` to explicitly skip peak stats. Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
           },
           "total_transitions": {
             "anyOf": [
@@ -1543,12 +1543,12 @@
               }
             ],
             "title": "Total Transitions",
-            "description": "Transitions to compute cumulative totals for. Returns median and CI."
+            "description": "Base transition names (e.g. `Susceptible_to_Infected`) to compute cumulative totals for. Omit to include every transition; pass `[]` to explicitly skip totals. Per-quantile total event counts are returned for each included age group."
           }
         },
         "type": "object",
         "title": "SummaryConfig",
-        "description": "Configuration for summary statistics."
+        "description": "Configuration for summary statistics.\n\nSummary is returned by default for every compartment and transition, broken\ndown by age group and by the quantiles requested in `output.quantiles`.\nUse the fields below to narrow that down."
       },
       "SummaryResults": {
         "properties": {

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -831,20 +831,13 @@
       },
       "PeakStatistic": {
         "properties": {
-          "median": {
-            "type": "number",
-            "title": "Median",
-            "description": "Median peak value across simulation runs."
-          },
-          "ci_95": {
-            "items": {
+          "quantiles": {
+            "additionalProperties": {
               "type": "number"
             },
-            "type": "array",
-            "maxItems": 2,
-            "minItems": 2,
-            "title": "Ci 95",
-            "description": "95% confidence interval [lower, upper]."
+            "type": "object",
+            "title": "Quantiles",
+            "description": "Peak value per quantile, e.g. `{\"0.025\": ..., \"0.5\": ..., \"0.975\": ...}`."
           },
           "peak_date": {
             "anyOf": [
@@ -856,16 +849,15 @@
               }
             ],
             "title": "Peak Date",
-            "description": "Date of the median peak."
+            "description": "Date of the peak from the median trajectory."
           }
         },
         "type": "object",
         "required": [
-          "median",
-          "ci_95"
+          "quantiles"
         ],
         "title": "PeakStatistic",
-        "description": "Peak statistic with date."
+        "description": "Peak statistic for a compartment in one age group."
       },
       "PopulationConfig": {
         "properties": {
@@ -1503,6 +1495,24 @@
         "title": "SimulationRunMetadata",
         "description": "Simulation section of metadata. Mirrors the `simulation` section of the request."
       },
+      "StatisticQuantiles": {
+        "properties": {
+          "quantiles": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Quantiles",
+            "description": "Quantile to value mapping, e.g. `{\"0.025\": ..., \"0.5\": ..., \"0.975\": ...}`."
+          }
+        },
+        "type": "object",
+        "required": [
+          "quantiles"
+        ],
+        "title": "StatisticQuantiles",
+        "description": "Quantile values for a summary statistic, keyed by quantile string (e.g. `0.5`)."
+      },
       "SummaryConfig": {
         "properties": {
           "peak_compartments": {
@@ -1546,7 +1556,10 @@
             "anyOf": [
               {
                 "additionalProperties": {
-                  "$ref": "#/components/schemas/PeakStatistic"
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/PeakStatistic"
+                  },
+                  "type": "object"
                 },
                 "type": "object"
               },
@@ -1555,13 +1568,16 @@
               }
             ],
             "title": "Peaks",
-            "description": "Peak statistics per compartment."
+            "description": "Peak statistics: `compartment -> age_group -> {quantiles, peak_date}`."
           },
           "totals": {
             "anyOf": [
               {
                 "additionalProperties": {
-                  "$ref": "#/components/schemas/SummaryStatistic"
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/StatisticQuantiles"
+                  },
+                  "type": "object"
                 },
                 "type": "object"
               },
@@ -1570,38 +1586,12 @@
               }
             ],
             "title": "Totals",
-            "description": "Total transition counts."
+            "description": "Cumulative transition totals: `transition -> age_group -> {quantiles}`."
           }
         },
         "type": "object",
         "title": "SummaryResults",
         "description": "Summary statistics of the simulation."
-      },
-      "SummaryStatistic": {
-        "properties": {
-          "median": {
-            "type": "number",
-            "title": "Median",
-            "description": "Median value across simulation runs."
-          },
-          "ci_95": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array",
-            "maxItems": 2,
-            "minItems": 2,
-            "title": "Ci 95",
-            "description": "95% confidence interval [lower, upper]."
-          }
-        },
-        "type": "object",
-        "required": [
-          "median",
-          "ci_95"
-        ],
-        "title": "SummaryStatistic",
-        "description": "A summary statistic with median and confidence interval."
       },
       "TrajectoriesResults": {
         "properties": {

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -1528,7 +1528,7 @@
               }
             ],
             "title": "Peak Compartments",
-            "description": "Compartment names to compute peak statistics for, e.g. `[\"Infected\"]`. Omit to include every compartment; pass `[]` to explicitly skip returning this summary. Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
+            "description": "By default, peak statistics are returned for every compartment. Pass a list to narrow the response, e.g. `[\"Infected\"]`, or pass `[]` to explicitly skip returning this summary. Per-quantile peak values and the median-trajectory peak date are returned for each included age group."
           },
           "total_transitions": {
             "anyOf": [
@@ -1543,7 +1543,7 @@
               }
             ],
             "title": "Total Transitions",
-            "description": "Transition names to compute cumulative totals for, e.g. `[\"Susceptible_to_Infected\"]`. Omit to include every transition; pass `[]` to explicitly skip returning this summary. Per-quantile total event counts are returned for each included age group."
+            "description": "By default, cumulative totals are returned for every transition. Pass a list to narrow the response, e.g. `[\"Susceptible_to_Infected\"]`, or pass `[]` to explicitly skip returning this summary. Per-quantile total event counts are returned for each included age group."
           }
         },
         "type": "object",

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -29,6 +29,29 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SimulationRequest"
+              },
+              "examples": {
+                "SIR": {
+                  "summary": "Basic SIR simulation",
+                  "description": "Run a Susceptible-Infected-Recovered model on the US population over two months.",
+                  "value": {
+                    "model": {
+                      "preset": "SIR",
+                      "parameters": {
+                        "transmission_rate": 0.3,
+                        "recovery_rate": 0.1
+                      }
+                    },
+                    "population": {
+                      "name": "United_States"
+                    },
+                    "simulation": {
+                      "start_date": "2024-01-01",
+                      "end_date": "2024-03-01",
+                      "Nsim": 10
+                    }
+                  }
+                }
               }
             }
           },
@@ -1336,26 +1359,7 @@
           "simulation"
         ],
         "title": "SimulationRequest",
-        "description": "Complete simulation request.",
-        "examples": [
-          {
-            "model": {
-              "parameters": {
-                "recovery_rate": 0.1,
-                "transmission_rate": 0.3
-              },
-              "preset": "SIR"
-            },
-            "population": {
-              "name": "United_States"
-            },
-            "simulation": {
-              "Nsim": 10,
-              "end_date": "2024-03-01",
-              "start_date": "2024-01-01"
-            }
-          }
-        ]
+        "description": "Complete simulation request."
       },
       "SimulationResponse": {
         "properties": {

--- a/web/static/openapi.json
+++ b/web/static/openapi.json
@@ -3,8 +3,18 @@
   "info": {
     "title": "epydemix WebAPI",
     "description": "REST API for running epidemic simulations with epydemix",
-    "version": "0.1.1"
+    "version": "0.2.0"
   },
+  "servers": [
+    {
+      "url": "https://epyscenario-api.isi.it",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:8000",
+      "description": "Local"
+    }
+  ],
   "paths": {
     "/api/v1/simulations": {
       "post": {
@@ -649,6 +659,36 @@
         "title": "ModelConfig",
         "description": "Epidemic model configuration. Use `preset` for a built-in model (SIR, SEIR, SIS), or provide `compartments`, `parameters`, and `transitions` for a custom model."
       },
+      "ModelMetadata": {
+        "properties": {
+          "preset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preset",
+            "description": "Preset name if a preset was used."
+          },
+          "compartments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Compartments",
+            "description": "Compartment names in the model."
+          }
+        },
+        "type": "object",
+        "required": [
+          "compartments"
+        ],
+        "title": "ModelMetadata",
+        "description": "Model section of simulation metadata. Mirrors the `model` section of the request."
+      },
       "OutputConfig": {
         "properties": {
           "quantiles": {
@@ -952,6 +992,81 @@
         "title": "PopulationListResponse",
         "description": "Response for listing all available populations."
       },
+      "PopulationMetadata": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Population identifier."
+          },
+          "contacts_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contacts Source",
+            "description": "Resolved contact matrix source actually used."
+          },
+          "layers": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layers",
+            "description": "Resolved contact layers actually used."
+          },
+          "age_group_mapping": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age Group Mapping",
+            "description": "Custom age group aggregation, echoed back if the request supplied one."
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total population size."
+          },
+          "age_groups": {
+            "items": {
+              "$ref": "#/components/schemas/AgeGroupInfo"
+            },
+            "type": "array",
+            "title": "Age Groups",
+            "description": "Population count per age group, in model order."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "total",
+          "age_groups"
+        ],
+        "title": "PopulationMetadata",
+        "description": "Population section of simulation metadata. Mirrors the `population` section of the request and adds resolved/derived values."
+      },
       "PopulationSummary": {
         "properties": {
           "name": {
@@ -1127,87 +1242,27 @@
       },
       "SimulationMetadata": {
         "properties": {
-          "model_preset": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Model Preset",
-            "description": "Preset name if a preset was used."
+          "model": {
+            "$ref": "#/components/schemas/ModelMetadata",
+            "description": "Model configuration used for the run."
           },
-          "compartments": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Compartments",
-            "description": "Compartment names in the model."
+          "population": {
+            "$ref": "#/components/schemas/PopulationMetadata",
+            "description": "Resolved population configuration and derived counts."
           },
-          "population_name": {
-            "type": "string",
-            "title": "Population Name",
-            "description": "Population identifier."
-          },
-          "population_size": {
-            "type": "integer",
-            "title": "Population Size",
-            "description": "Total population size."
-          },
-          "n_age_groups": {
-            "type": "integer",
-            "title": "N Age Groups",
-            "description": "Number of age groups."
-          },
-          "start_date": {
-            "type": "string",
-            "title": "Start Date",
-            "description": "Simulation start date."
-          },
-          "end_date": {
-            "type": "string",
-            "title": "End Date",
-            "description": "Simulation end date."
-          },
-          "n_simulations": {
-            "type": "integer",
-            "title": "N Simulations",
-            "description": "Number of simulation runs."
-          },
-          "dt": {
-            "type": "number",
-            "title": "Dt",
-            "description": "Time step in days."
-          },
-          "seed": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Seed",
-            "description": "Random seed used."
+          "simulation": {
+            "$ref": "#/components/schemas/SimulationRunMetadata",
+            "description": "Simulation execution parameters used for the run."
           }
         },
         "type": "object",
         "required": [
-          "compartments",
-          "population_name",
-          "population_size",
-          "n_age_groups",
-          "start_date",
-          "end_date",
-          "n_simulations",
-          "dt"
+          "model",
+          "population",
+          "simulation"
         ],
         "title": "SimulationMetadata",
-        "description": "Metadata about the simulation run."
+        "description": "Metadata about the simulation run, grouped to mirror the request shape."
       },
       "SimulationRequest": {
         "properties": {
@@ -1319,7 +1374,8 @@
             "description": "Whether the simulation completed successfully."
           },
           "metadata": {
-            "$ref": "#/components/schemas/SimulationMetadata"
+            "$ref": "#/components/schemas/SimulationMetadata",
+            "description": "Metadata about the simulation run."
           },
           "results": {
             "anyOf": [
@@ -1391,6 +1447,57 @@
         ],
         "title": "SimulationResultsData",
         "description": "All simulation results."
+      },
+      "SimulationRunMetadata": {
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "title": "Start Date",
+            "description": "Simulation start date."
+          },
+          "end_date": {
+            "type": "string",
+            "title": "End Date",
+            "description": "Simulation end date."
+          },
+          "Nsim": {
+            "type": "integer",
+            "title": "Nsim",
+            "description": "Number of simulation runs."
+          },
+          "dt": {
+            "type": "number",
+            "title": "Dt",
+            "description": "Time step in days."
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Random seed used."
+          },
+          "resample_frequency": {
+            "type": "string",
+            "title": "Resample Frequency",
+            "description": "Resampling frequency."
+          }
+        },
+        "type": "object",
+        "required": [
+          "start_date",
+          "end_date",
+          "Nsim",
+          "dt",
+          "resample_frequency"
+        ],
+        "title": "SimulationRunMetadata",
+        "description": "Simulation section of metadata. Mirrors the `simulation` section of the request."
       },
       "SummaryConfig": {
         "properties": {
@@ -1681,16 +1788,6 @@
     {
       "name": "Model Presets",
       "description": "List built-in epidemic models (SIR, SEIR, SIS) with their compartments, parameters, and transitions."
-    }
-  ],
-  "servers": [
-    {
-      "url": "https://epyscenario-api.isi.it",
-      "description": "Production"
-    },
-    {
-      "url": "http://localhost:8000",
-      "description": "Local"
     }
   ]
 }


### PR DESCRIPTION
## Overview

Refactor `POST /v1/simulations`:
- Closes #13: `metadata` is nested into `model`, `population`, and `simulation` sections that mirror the request, and the `population` section carries per-age-group counts + the resolved `contacts_source` / `layers`.
- Closes #14: `results.summary` is nested by age group, and stats are keyed by quantile instead of a fixed `ci_95` pair.

## Changes

- **Metadata** is nested into `model` / `population` / `simulation` sections that mirror the request, with consistent field names (`Nsim`, `dt`, `seed`, `contacts_source`, `layers`).
- **Population metadata** now includes `total`, per-group `age_groups`, and returns the resolved `contacts_source`, `layers`, and `age_group_mapping`.
- **Summary** is always returned by default. `peaks` and `totals` are broken down by age group, and each stat reports a `quantiles` dict driven by `output.quantiles` (default: seven standard quantiles). Pass `[]` to explicitly skip.

## Examples

### Metadata

```json
"metadata": {
  "model": {
    "preset": "SIR",
    "compartments": ["Susceptible", "Infected", "Recovered"]
  },
  "population": {
    "name": "United_States",
    "contacts_source": "mistry_2021",
    "layers": ["home", "work", "school", "community"],
    "age_group_mapping": null,
    "total": 338120586,
    "age_groups": [
      { "name": "0-4",   "population": 18608139 },
      { "name": "5-19",  "population": 63540783 },
      { "name": "20-49", "population": 132780169 },
      { "name": "50-64", "population": 63172279 },
      { "name": "65+",   "population": 60019216 }
    ]
  },
  "simulation": {
    "start_date": "2024-01-01",
    "end_date": "2024-06-01",
    "Nsim": 10,
    "dt": 1.0,
    "seed": null,
    "resample_frequency": "D"
  }
}
```

### Summary (default shape)

```json
"summary": {
  "peaks": {
    "Infected": {
      "total": {
        "quantiles": { "0.025": 12200000.0, "0.5": 12400000.0, "0.975": 12600000.0 },
        "peak_date": "2024-02-14"
      },
      "0-4": { "quantiles": { "0.5": 420000.0 }, "peak_date": "2024-02-13" }
    }
  },
  "totals": {
    "Susceptible_to_Infected": {
      "total": { "quantiles": { "0.025": 2.13e8, "0.5": 2.15e8, "0.975": 2.17e8 } },
      "0-4":   { "quantiles": { "0.5": 11800000.0 } }
    }
  }
}
```

## Migration

Breaking changes. Clients need to update in three places:

### 1. Metadata field paths

| Before | After |
|---|---|
| `metadata.model_preset` | `metadata.model.preset` |
| `metadata.compartments` | `metadata.model.compartments` |
| `metadata.population_name` | `metadata.population.name` |
| `metadata.population_size` | `metadata.population.total` |
| `metadata.n_age_groups` | `len(metadata.population.age_groups)` |
| `metadata.n_simulations` | `metadata.simulation.Nsim` |
| `metadata.start_date` | `metadata.simulation.start_date` |
| `metadata.end_date` | `metadata.simulation.end_date` |
| `metadata.dt` | `metadata.simulation.dt` |
| `metadata.seed` | `metadata.simulation.seed` |

### 2. Summary shape

- `summary.peaks.Infected.median` -> `summary.peaks.Infected.total.quantiles["0.5"]`
- `summary.peaks.Infected.ci_95[0]` -> `summary.peaks.Infected.total.quantiles["0.025"]`
- `summary.peaks.Infected.ci_95[1]` -> `summary.peaks.Infected.total.quantiles["0.975"]`
- `summary.peaks.Infected.peak_date` -> `summary.peaks.Infected.total.peak_date`
- `summary.totals.Susceptible_to_Infected.median` -> `summary.totals.Susceptible_to_Infected.total.quantiles["0.5"]`

### 3. Summary input semantics

- `output.summary.peak_compartments` / `total_transitions` no longer accept age-suffixed names like `"Infected_0-4"`. Use base names and control age groups via `output.age_groups`.
- Omitting these fields now defaults to "all" rather than "none". Pass `[]` to explicitly skip.